### PR TITLE
include <iostream>

### DIFF
--- a/lib/playapi/util/config.cpp
+++ b/lib/playapi/util/config.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "config.h"
 
 #include <regex>


### PR DESCRIPTION
Needed on OSX to prevent `error: invalid operands to binary expression ('std::ostream' (aka 'basic_ostream<char>') and 'int')`