### PR TITLE
Add BetaInfo

### DIFF
--- a/proto/play_document.proto
+++ b/proto/play_document.proto
@@ -244,6 +244,11 @@ message AppDetails {
     optional int32 targetSdkVersion = 32;
     optional string preregistrationPromoCode = 33;
     optional download.InstallDetails installDetails = 34;
+    optional TestingProgramInfo testingProgramInfo = 35;
+}
+message TestingProgramInfo {
+    optional bool subscribed = 2;
+    optional bool subscribed1 = 3;
 }
 message AlbumDetails {
     optional string name = 1;


### PR DESCRIPTION
This PR allows the minecraft-linux launcher to detect if the user is in the beta program.

With this `1.16.0.63` can be transformed to `1.16.0.63 (BETA)`.
`1.16.0.63` is the latest as of writing this PR.